### PR TITLE
Removed yamlfix so we can rely on antsibull only

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ certifi
 charset-normalizer
 idna
 antsibull-changelog
-yamlfix

--- a/script.py
+++ b/script.py
@@ -8,7 +8,6 @@ import yaml
 import datetime
 import os
 import re
-import yamlfix, yamlfix.model
 from pathlib import Path
 
 class Dumper(yaml.Dumper):
@@ -184,11 +183,6 @@ with open(change_log_path) as f:
     dataMap['releases'][target_version] = change_log
 with open(change_log_path, 'w') as f:
     yaml.dump(dataMap, f)
-    # Adjusts the output changelog.yaml to comply with strict ansible-lint requirements for Ansible Galaxy.
-    config = yamlfix.model.YamlfixConfig()
-    config.line_length = 120
-    config.none_representation = 'null'
-    yamlfix.fix_files([change_log_path], config=config)
 
 # edit changelog.yaml as we want
 # os.system("vim {0}".format(change_log_path))


### PR DESCRIPTION
antsibull-changelog now has a `changelog_nice_yaml` option to fix ansible linting issues.
https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelog-configuration.md#changelog_nice_yaml-boolean